### PR TITLE
Fix useKDE option within rbuic4

### DIFF
--- a/ext/ruby/qtruby/tools/rbuic/option.h
+++ b/ext/ruby/qtruby/tools/rbuic/option.h
@@ -94,7 +94,10 @@ struct Option
           autoConnection(1),
           dependencies(0),
           extractImages(0),
+#ifdef QT_UIC_RUBY_GENERATOR
           execCode(0),
+          useKDE(0),
+#endif
           generator(RubyGenerator),
           prefix(QLatin1String("Ui_"))
     { indent.fill(QLatin1Char(' '), 4); }


### PR DESCRIPTION
Currently the KDE specific code is being added to the ui's rb file when rbuic4 is used. This should be controlled by the -k flag.

This should be turned off by default.
